### PR TITLE
Use of hard-coded passwords is a bad practice 

### DIFF
--- a/contrail/environment/modules/contrail/hiera.yaml
+++ b/contrail/environment/modules/contrail/hiera.yaml
@@ -1,0 +1,6 @@
+:hierarchy:
+  - common
+:backends:
+  - yaml
+:yaml:
+:datadir: 'hieradata'

--- a/contrail/environment/modules/contrail/hieradata/common.yaml
+++ b/contrail/environment/modules/contrail/hieradata/common.yaml
@@ -1,0 +1,3 @@
+---
+cmon_db_pwd: cmon
+keystone_db_pwd: keystone

--- a/contrail/environment/modules/contrail/manifests/ha_config.pp
+++ b/contrail/environment/modules/contrail/manifests/ha_config.pp
@@ -117,9 +117,9 @@ class contrail::ha_config (
         }
 
         $cmon_db_user = "cmon"
-        $cmon_db_pass = "cmon"
+        $cmon_db_pass = hiera('cmon_db_pwd')
         $keystone_db_user = "keystone"
-        $keystone_db_pass = "keystone"
+        $keystone_db_pass = hiera('keystone_db_pwd')
         # Hard-coded to true because this code runs only when internal vip is defined
         $monitor_galera="True"
 


### PR DESCRIPTION
Greetings, 

I am a security researcher, who is looking for security smells in Puppet scripts. 
I noticed instances of hard-coded passwords, which are against the best practices 
recommended by Common Weakness Enumeration (CWE) [https://cwe.mitre.org/data/definitions/259.html] and also by other security practitioners.
I have added hiera support to mitigate this smell. Feedback is welcome. 